### PR TITLE
Add simple Flask UI for crypto alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cointracker
 
 Cointracker is a simple email alert service for Bitcoin (BTC) and Ethereum (ETH).
-It periodically polls market data from the CoinGecko API and notifies you when
+It polls market data from the CoinGecko API and the Fear & Greed Index and notifies you when
 several bearish indicators align.
 
 ## Description
@@ -41,10 +41,16 @@ market is in a state of fear, an email alert is sent.
    export CHECK_INTERVAL="3600"
    ```
 
-2. Run the alert service:
+2. Run the background alert service:
 
    ```bash
    python app/alert_service.py
+   ```
+
+3. Alternatively launch the web interface:
+
+   ```bash
+   python app/web_app.py
    ```
 
 ## Features
@@ -59,4 +65,3 @@ market is in a state of fear, an email alert is sent.
 - Support additional cryptocurrencies
 - Provide command‑line arguments for thresholds and coins
 - Optionally log alerts to a file or database
-

--- a/app/web_app.py
+++ b/app/web_app.py
@@ -1,0 +1,36 @@
+from flask import Flask, render_template_string
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+from alert_service import check_conditions
+
+app = Flask(__name__)
+
+INDEX_HTML = """
+<!doctype html>
+<title>Cointracker Alert</title>
+<h1>Send Crypto Alert</h1>
+<form method="post" action="/send">
+    <button type="submit">Check & Send</button>
+</form>
+{% if result %}
+<p>{{ result }}</p>
+{% endif %}
+"""
+
+@app.route("/")
+def index():
+    return render_template_string(INDEX_HTML, result=None)
+
+@app.route("/send", methods=["POST"])
+def send():
+    try:
+        check_conditions()
+        msg = "Check completed. If conditions met, an email was sent."
+    except Exception as exc:  # noqa: BLE001
+        msg = f"Error: {exc}"
+    return render_template_string(INDEX_HTML, result=msg)
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+flask


### PR DESCRIPTION
## Summary
- add a small Flask web app to trigger `check_conditions`
- include Flask in requirements
- document installation and usage in README

## Testing
- `python -m py_compile app/alert_service.py app/web_app.py`

------
https://chatgpt.com/codex/tasks/task_e_687eced6b628832ea225d6eb54f9a5a2